### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
 runs:
   using: 'docker'
   # This is the image that will be used to run the action. The version of the image is changed automatically by releasing a new version of the action.
-  image: 'docker://asyncapi/github-action-for-cli:1.1.0'
+  image: 'docker://asyncapi/github-action-for-cli:1.2.0'
   args:
     - ${{ inputs.cli_version }}
     - ${{ inputs.command }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-action-for-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-action-for-cli",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github-action-for-cli",
   "description": "This is to be used for running tests for the GitHub Action using the MakeFile",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "test": "make test",
     "generate:assets": "echo 'No additional assets need to be generated at the moment'",


### PR DESCRIPTION
Version bump in package.json for release [v1.2.0](https://github.com/ash17290/github-action-for-cli/releases/tag/v1.2.0)